### PR TITLE
Backend: more handler integration tests

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,14 +3,20 @@ module github.com/oskarilindroos/review-app
 go 1.22.1
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/gorilla/mux v1.8.1	
-    github.com/go-sql-driver/mysql v1.8.0 // indirect
+	github.com/Henry-Sarabia/igdb/v2 v2.0.0-alpha.4
+	github.com/go-sql-driver/mysql v1.8.0
+	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.9.0
+)
 
+require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Henry-Sarabia/apicalypse v1.0.2 // indirect
 	github.com/Henry-Sarabia/blank v3.0.0+incompatible // indirect
 	github.com/Henry-Sarabia/sliceconv v1.0.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/Henry-Sarabia/igdb/v2 v2.0.0-alpha.4
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,3 @@
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Henry-Sarabia/apicalypse v1.0.2 h1:rM2SrWlMgNwyuzP/Ty8dvc5iYb1pWVGa+kF0RvSPMoE=
@@ -11,6 +9,8 @@ github.com/Henry-Sarabia/igdb/v2 v2.0.0-alpha.4 h1:ZsyBtHcuEBVyrsP2oYIHELEAt/W18
 github.com/Henry-Sarabia/igdb/v2 v2.0.0-alpha.4/go.mod h1:ooRt7UmyP40FAZncIkpM6fJ0LBUD3aMNRJQfLxGCCG8=
 github.com/Henry-Sarabia/sliceconv v1.0.2 h1:1zH/sJmocRZz1g1FrmU06GsbskWLWglj6IHhFB9TdBA=
 github.com/Henry-Sarabia/sliceconv v1.0.2/go.mod h1:FNvuZcThTpCgAjQQZjPSx7PkS/DYRT6jTV3oPQGP2lU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.8.0 h1:UtktXaU2Nb64z/pLiGIxY4431SJ4/dR5cjMmlVHgnT4=
 github.com/go-sql-driver/mysql v1.8.0/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -19,3 +19,11 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/db/connectToDB.go
+++ b/backend/internal/db/connectToDB.go
@@ -27,7 +27,7 @@ func ConnectToDB() (*sql.DB, error) {
 		log.Fatal(err)
 		return nil, err
 	}
-	
+
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
 
@@ -36,7 +36,6 @@ func ConnectToDB() (*sql.DB, error) {
 		log.Fatal(pingErr)
 		return nil, pingErr
 	}
-	log.Println("Connected to database")
 
 	return db, nil
 }

--- a/backend/internal/games/games_handler_test.go
+++ b/backend/internal/games/games_handler_test.go
@@ -18,13 +18,12 @@ import (
 	"github.com/oskarilindroos/review-app/internal/models"
 )
 
-const(
-	testGetGameByIdHandlerWithReviews string ="test_data/games_handler_get_game_by_ID_with_reviews.json"
-	testGetGameByIdHandlerNoReviews string ="test_data/games_handler_get_game_by_ID_no_reviews.json"
-
+const (
+	testGetGameByIdHandlerWithReviews string = "test_data/games_handler_get_game_by_ID_with_reviews.json"
+	testGetGameByIdHandlerNoReviews   string = "test_data/games_handler_get_game_by_ID_no_reviews.json"
 )
 
-func TestGetGamesHandler(t *testing.T){
+func TestGetGamesHandler(t *testing.T) {
 
 	t.Setenv("TWITCH_CLIENT_ID", "08pq42o75ypbgn28lkygv407r9apgr")
 	t.Setenv("IGDB_TOKEN_TILL_17_05", "69ai7xb1ccdubbj0qehfnufzcfx8yp")
@@ -33,7 +32,7 @@ func TestGetGamesHandler(t *testing.T){
 	if err != nil {
 		t.Fatal(err)
 	}
-	single := make([]*models.GamesList,0)
+	single := make([]*models.GamesList, 0)
 	err = json.Unmarshal(f1, &single)
 	if err != nil {
 		t.Fatal(err)
@@ -43,52 +42,52 @@ func TestGetGamesHandler(t *testing.T){
 	if err != nil {
 		t.Fatal(err)
 	}
-	multi := make([]*models.GamesList,0)
+	multi := make([]*models.GamesList, 0)
 	err = json.Unmarshal(f2, &multi)
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler:= games.GamesHandler{}
-	
-	var tests = []struct{
-		name 				string
-		page_number 		string
-		number_of_games 	string
-		order 				string
-		order_by 			string
-		wantSuccessBody		[]*models.GamesList
-		wantErrorBody		string
-		wantCode			int
+	handler := games.GamesHandler{}
+
+	var tests = []struct {
+		name            string
+		page_number     string
+		number_of_games string
+		order           string
+		order_by        string
+		wantSuccessBody []*models.GamesList
+		wantErrorBody   string
+		wantCode        int
 	}{
-		{"get single game with status ok","1","1","desc","relevance",single,"", http.StatusOK},
-		{"get list of games with status ok","1","10","asc","id",multi,"", http.StatusOK},
-		{"Get error empty variables","","","","",nil,
-		`{"error":"cannot get index of Games: cannot create request with invalid options: cannot unwrap invalid option: cannot compose invalid functional options: cannot unwrap invalid option: one or more provided option field values are empty"}`,
-		http.StatusInternalServerError},
-		{"Get error number out of range","1","-1","asc","hypes",nil,
-		`{"error":"Page number was lower than 1 needs to be 1 or higher"}`,
-		http.StatusInternalServerError},
+		{"get single game with status ok", "1", "1", "desc", "relevance", single, "", http.StatusOK},
+		{"get list of games with status ok", "1", "10", "asc", "id", multi, "", http.StatusOK},
+		{"Get error empty variables", "", "", "", "", nil,
+			`{"error":"cannot get index of Games: cannot create request with invalid options: cannot unwrap invalid option: cannot compose invalid functional options: cannot unwrap invalid option: one or more provided option field values are empty"}`,
+			http.StatusInternalServerError},
+		{"Get error number out of range", "1", "-1", "asc", "hypes", nil,
+			`{"error":"Page number was lower than 1 needs to be 1 or higher"}`,
+			http.StatusInternalServerError},
 	}
 
-	for _, test := range tests{
+	for _, test := range tests {
 
-		t.Run(test.name,func(t *testing.T) {
-			resp:=httptest.NewRecorder()
-		
-			req := httptest.NewRequest("GET","/",nil)
+		t.Run(test.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+
+			req := httptest.NewRequest("GET", "/", nil)
 
 			q := req.URL.Query()
-			q.Add("page_number",test.page_number)
-			q.Add("number_of_games",test.number_of_games)
-			q.Add("order",test.order)
-			q.Add("order_by",test.order_by)
-			req.URL.RawQuery= q.Encode()
+			q.Add("page_number", test.page_number)
+			q.Add("number_of_games", test.number_of_games)
+			q.Add("order", test.order)
+			q.Add("order_by", test.order_by)
+			req.URL.RawQuery = q.Encode()
 			handler.GetGamesHandler(resp, req)
 
 			if resp.Result().StatusCode != test.wantCode {
-				t.Fatalf("The status code should be <%v> but received <%v>",test.wantCode,resp.Result().StatusCode)
+				t.Fatalf("The status code should be <%v> but received <%v>", test.wantCode, resp.Result().StatusCode)
 			}
-			if resp.Result().StatusCode == http.StatusOK{
+			if resp.Result().StatusCode == http.StatusOK {
 
 				bb := resp.Body.Bytes()
 				c := []*models.GamesList{}
@@ -97,23 +96,23 @@ func TestGetGamesHandler(t *testing.T){
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(test.wantSuccessBody,c){
-					t.Fatalf("Wanted in body: <%v> \ngot: <%v>",test.wantSuccessBody,c)
+				if !reflect.DeepEqual(test.wantSuccessBody, c) {
+					t.Fatalf("Wanted in body: <%v> \ngot: <%v>", test.wantSuccessBody, c)
 				}
-			}else{
+			} else {
 				bb := resp.Body.String()
 				cc := test.wantErrorBody
-				d :=  strings.TrimSpace(bb)
-				if d != cc{
-					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'",cc,d)
+				d := strings.TrimSpace(bb)
+				if d != cc {
+					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'", cc, d)
 				}
 			}
-			
+
 		})
 	}
 }
 
-func TestSearchGamesHandler(t *testing.T){
+func TestSearchGamesHandler(t *testing.T) {
 
 	t.Setenv("TWITCH_CLIENT_ID", "08pq42o75ypbgn28lkygv407r9apgr")
 	t.Setenv("IGDB_TOKEN_TILL_17_05", "69ai7xb1ccdubbj0qehfnufzcfx8yp")
@@ -122,47 +121,47 @@ func TestSearchGamesHandler(t *testing.T){
 	if err != nil {
 		t.Fatal(err)
 	}
-	init := make([]*models.GamesList,0)
+	init := make([]*models.GamesList, 0)
 	err = json.Unmarshal(f, &init)
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler:= games.GamesHandler{}
-	
-	var tests = []struct{
-		name 				string
-		page_number 		string
-		number_of_games 	string
-		search 				string
-		wantSuccessBody		[]*models.GamesList
-		wantErrorBody		string
-		wantCode			int
+	handler := games.GamesHandler{}
+
+	var tests = []struct {
+		name            string
+		page_number     string
+		number_of_games string
+		search          string
+		wantSuccessBody []*models.GamesList
+		wantErrorBody   string
+		wantCode        int
 	}{
-		{"search games with status ok","1","3","zelda",init,"", http.StatusOK},
-		{"Get error empty variables","","","",nil, `{"error":"Did not give search parameters"}`,400},
-		{"Get error number out of range","1","-1","zelda",nil, `{"error":"Page number was lower than 1 needs to be 1 or higher"}`, http.StatusInternalServerError},
+		{"search games with status ok", "1", "3", "zelda", init, "", http.StatusOK},
+		{"Get error empty variables", "", "", "", nil, `{"error":"Did not give search parameters"}`, 400},
+		{"Get error number out of range", "1", "-1", "zelda", nil, `{"error":"Page number was lower than 1 needs to be 1 or higher"}`, http.StatusInternalServerError},
 	}
 
-	for _, test := range tests{
+	for _, test := range tests {
 
-		t.Run(test.name,func(t *testing.T) {
-			resp:=httptest.NewRecorder()
-		
-			req := httptest.NewRequest("GET","/search",nil)
+		t.Run(test.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+
+			req := httptest.NewRequest("GET", "/search", nil)
 
 			q := req.URL.Query()
-			q.Add("page_number",test.page_number)
-			q.Add("number_of_games",test.number_of_games)
-			q.Add("search_content",test.search)
-			req.URL.RawQuery= q.Encode()
+			q.Add("page_number", test.page_number)
+			q.Add("number_of_games", test.number_of_games)
+			q.Add("search_content", test.search)
+			req.URL.RawQuery = q.Encode()
 			handler.SearchGamesHandler(resp, req)
 
 			if resp.Result().StatusCode != test.wantCode {
-				log.Printf("status: %v",resp.Body.String())
-				t.Fatalf("The status code should be <%v> but received <%v>",test.wantCode,resp.Result().StatusCode)
-			
+				log.Printf("status: %v", resp.Body.String())
+				t.Fatalf("The status code should be <%v> but received <%v>", test.wantCode, resp.Result().StatusCode)
+
 			}
-			if resp.Result().StatusCode == http.StatusOK{
+			if resp.Result().StatusCode == http.StatusOK {
 
 				bb := resp.Body.Bytes()
 				c := []*models.GamesList{}
@@ -171,33 +170,33 @@ func TestSearchGamesHandler(t *testing.T){
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(test.wantSuccessBody,c){
-					t.Fatalf("Wanted in body: <%v> \ngot: <%v>",test.wantSuccessBody,c)
+				if !reflect.DeepEqual(test.wantSuccessBody, c) {
+					t.Fatalf("Wanted in body: <%v> \ngot: <%v>", test.wantSuccessBody, c)
 				}
-			}else{
+			} else {
 				bb := resp.Body.String()
 				cc := test.wantErrorBody
-				d :=  strings.TrimSpace(bb)
-				if d != cc{
-					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'",cc,d)
+				d := strings.TrimSpace(bb)
+				if d != cc {
+					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'", cc, d)
 				}
 			}
-			
+
 		})
 	}
 }
 
-func TestGetGameByIdHandler(t *testing.T){
+func TestGetGameByIdHandler(t *testing.T) {
 
 	t.Setenv("TWITCH_CLIENT_ID", "08pq42o75ypbgn28lkygv407r9apgr")
 	t.Setenv("IGDB_TOKEN_TILL_17_05", "69ai7xb1ccdubbj0qehfnufzcfx8yp")
-	t.Setenv("DB_PASSWORD","dev")
-	t.Setenv("CORS_ORIGIN","http://localhost:5173")
-	t.Setenv("PORT","5050")
-	t.Setenv("DB_USER","dev")
-	t.Setenv("DB_NET","tcp")
-	t.Setenv("DB_ADDR","localhost")
-	t.Setenv("DB_DATABASE","reviewapp")
+	t.Setenv("DB_PASSWORD", "dev")
+	t.Setenv("CORS_ORIGIN", "http://localhost:5173")
+	t.Setenv("PORT", "5050")
+	t.Setenv("DB_USER", "dev")
+	t.Setenv("DB_NET", "tcp")
+	t.Setenv("DB_ADDR", "localhost")
+	t.Setenv("DB_DATABASE", "reviewapp")
 
 	db, err := db.ConnectToDB()
 	if err != nil {
@@ -214,7 +213,7 @@ func TestGetGameByIdHandler(t *testing.T){
 	games.SetupRoutes(r, gamesHandler) // Setup /api/games routes
 	r.Use(middleware.Cors)
 
-	type b struct{	
+	type b struct {
 		ID      int       `json:"reviewId" db:"id"`
 		IGDBID  string    `json:"igdbId" db:"igdb_id"`
 		UserID  *string   `json:"userId" db:"user_id"` // WARN: Nullable
@@ -223,18 +222,17 @@ func TestGetGameByIdHandler(t *testing.T){
 		Created time.Time `json:"createdAt" db:"created"`
 		Updated time.Time `json:"updatedAt" db:"updated"`
 	}
-	type a struct{
-		GameID      int                  `json:"igdbId"`
-		Name        string               `json:"name"`
-		Cover       string               `json:"coverUrl"`
-		AgeRating   string               `json:"ageRating"`
-		ReleaseDate int                  `json:"releaseDate"`
-		Genres      string               `json:"genres"`
-		Storyline   string               `json:"storyline"`
-		Summary     string               `json:"summary"`
-		Reviews     []b		 			`json:"reviews"`
+	type a struct {
+		GameID      int    `json:"igdbId"`
+		Name        string `json:"name"`
+		Cover       string `json:"coverUrl"`
+		AgeRating   string `json:"ageRating"`
+		ReleaseDate int    `json:"releaseDate"`
+		Genres      string `json:"genres"`
+		Storyline   string `json:"storyline"`
+		Summary     string `json:"summary"`
+		Reviews     []b    `json:"reviews"`
 	}
-
 
 	f, err := os.ReadFile(testGetGameByIdHandlerWithReviews)
 	if err != nil {
@@ -254,44 +252,38 @@ func TestGetGameByIdHandler(t *testing.T){
 	if err != nil {
 		t.Fatal(err)
 	}
-	
-	
-	var tests = []struct{
-		name 				string
-		gameID				string
-		wantSuccessBody		*a
-		wantErrorBody		string
-		wantCode			int
+
+	var tests = []struct {
+		name            string
+		gameID          string
+		wantSuccessBody *a
+		wantErrorBody   string
+		wantCode        int
 	}{
-		{"Get game data successfully","131913",withReviews,"",http.StatusOK},
-		{"Get game data successfully","13191",noReviews,"",http.StatusOK},
-		{"Invalid ID","-1",nil,`{"error":"ID cannot be negative"}`, http.StatusInternalServerError},
-		{"Zero Id","0",nil,`{"error":"cannot get Game with ID 0: cannot make POST request: results are empty"}`, http.StatusInternalServerError},
+		{"Get game data successfully", "131913", withReviews, "", http.StatusOK},
+		{"Get game data successfully", "13191", noReviews, "", http.StatusOK},
+		{"Invalid ID", "-1", nil, `{"error":"ID cannot be negative"}`, http.StatusInternalServerError},
+		{"Zero Id", "0", nil, `{"error":"cannot get Game with ID 0: cannot make POST request: results are empty"}`, http.StatusInternalServerError},
 	}
 
-	for _, test := range tests{
+	for _, test := range tests {
 
-		t.Run(test.name,func(t *testing.T) {
-			resp:=httptest.NewRecorder()
+		t.Run(test.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
 
-			
+			req := httptest.NewRequest("GET", "/{igdbId}", nil)
+			req = mux.SetURLVars(req, map[string]string{"igdbId": test.gameID})
 
-
-
-			req:= httptest.NewRequest("GET","/{igdbId}",nil)
-			req = mux.SetURLVars(req,map[string]string{"igdbId":test.gameID})
-	
 			q := req.URL.Query()
-			req.URL.RawQuery= q.Encode()
-			
+			req.URL.RawQuery = q.Encode()
+
 			gamesHandler.GetGameByIdHandler(resp, req)
 
-
 			if resp.Result().StatusCode != test.wantCode {
-				t.Fatalf("The status code should be <%v> but received <%v>",test.wantCode,resp.Result().StatusCode)
-			
+				t.Fatalf("The status code should be <%v> but received <%v>", test.wantCode, resp.Result().StatusCode)
+
 			}
-			if resp.Result().StatusCode == http.StatusOK{
+			if resp.Result().StatusCode == http.StatusOK {
 
 				bb := resp.Body.Bytes()
 				c := &a{}
@@ -300,18 +292,18 @@ func TestGetGameByIdHandler(t *testing.T){
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(test.wantSuccessBody,c){
-					t.Fatalf("Wanted in body: <%v> \ngot: <%v>",test.wantSuccessBody,c)
+				if !reflect.DeepEqual(test.wantSuccessBody, c) {
+					t.Fatalf("Wanted in body: <%v> \ngot: <%v>", test.wantSuccessBody, c)
 				}
-			}else{
+			} else {
 				bb := resp.Body.String()
 				cc := test.wantErrorBody
-				d :=  strings.TrimSpace(bb)
-				if d != cc{
-					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'",cc,d)
+				d := strings.TrimSpace(bb)
+				if d != cc {
+					t.Fatalf("Wanted error message '<%v>' \n got '<%v>'", cc, d)
 				}
 			}
-			
+
 		})
 	}
 }

--- a/backend/internal/games/games_handler_testify_test.go
+++ b/backend/internal/games/games_handler_testify_test.go
@@ -1,0 +1,232 @@
+package games_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
+	"github.com/oskarilindroos/review-app/internal/db"
+	"github.com/oskarilindroos/review-app/internal/games"
+	"github.com/oskarilindroos/review-app/internal/middleware"
+	"github.com/oskarilindroos/review-app/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup a test env for integration tests
+func setupTestEnvironment(t *testing.T) *games.GamesHandler {
+	// Load development environment variables
+	godotenv.Load("../../.env.development")
+
+	// Set test environment variables
+	t.Setenv("PORT", os.Getenv("PORT"))
+	t.Setenv("DB_USER", os.Getenv("DB_USER"))
+	t.Setenv("DB_PASSWORD", os.Getenv("DB_PASSWORD"))
+	t.Setenv("DB_NAME", os.Getenv("DB_NAME"))
+	t.Setenv("DB_HOST", os.Getenv("DB_HOST"))
+	t.Setenv("IGDB_TOKEN_TILL_17_05", os.Getenv("IGDB_TOKEN_TILL_17_05"))
+
+	db, err := db.ConnectToDB()
+	if err != nil {
+		t.Fatalf("Error connecting to database: %v", err)
+	}
+
+	r := mux.NewRouter()
+
+	// Setup games service, repository and handler
+	gamesRepo := games.NewMYSQLGameReviewsRepository(db)
+	gamesService := games.NewGamesService(gamesRepo)
+	gamesHandler := games.NewGamesHandler(gamesService)
+	games.SetupRoutes(r, gamesHandler) // Setup /api/games routes
+	r.Use(middleware.Cors)
+
+	return gamesHandler
+}
+
+func TestGetAllGameReviewsHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Success", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/reviews", nil)
+		gamesHandler.GetAllGameReviewsHandler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "reviewId")
+	})
+}
+
+func TestGetGameReviewByIDHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Success", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/reviews/{reviewId}", nil)
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "1"})
+
+		gamesHandler.GetGameReviewByIDHandler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "reviewId")
+	})
+
+	t.Run("Not found", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/reviews/{reviewId}", nil)
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "999999"})
+
+		gamesHandler.GetGameReviewByIDHandler(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "error")
+	})
+
+	t.Run("Invalid ID", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/reviews/{reviewId}", nil)
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "invalid"})
+
+		gamesHandler.GetGameReviewByIDHandler(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "error")
+	})
+}
+
+func TestGetGameReviewsByIGDBIDHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Success", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/{igdbId}/reviews", nil)
+		req = mux.SetURLVars(req, map[string]string{"igdbId": "131913"})
+
+		gamesHandler.GetGameReviewsByIGDBIDHandler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "reviewId")
+	})
+
+	t.Run("Not found", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/games/{igdbId}/reviews", nil)
+		req = mux.SetURLVars(req, map[string]string{"igdbId": "999999"})
+
+		gamesHandler.GetGameReviewsByIGDBIDHandler(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "error")
+	})
+}
+
+func TestCreateGameReviewHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Success", func(t *testing.T) {
+		// Create a payload for creating a review
+		newReview := models.GameReview{
+			IGDBID: "131913",
+			Review: "Test review",
+			Rating: "5",
+		}
+		newReviewJSON, err := json.Marshal(newReview)
+		if err != nil {
+			t.Fatalf("Error marshalling new review: %v", err)
+		}
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/games/{igdbId}/reviews", bytes.NewReader(newReviewJSON))
+		req = mux.SetURLVars(req, map[string]string{"igdbId": "131913"})
+
+		gamesHandler.CreateGameReviewHandler(rr, req)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "reviewId")
+	})
+}
+
+func TestUpdateGameReviewHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Success", func(t *testing.T) {
+		// Create a payload for updating a review
+		updatedReview := models.GameReview{
+			Review: "Updated review",
+			Rating: "1",
+		}
+		updatedReviewJSON, err := json.Marshal(updatedReview)
+		if err != nil {
+			t.Fatalf("Error marshalling updated review: %v", err)
+		}
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/games/reviews/{reviewId}", bytes.NewReader(updatedReviewJSON))
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "1"})
+
+		gamesHandler.UpdateGameReviewHandler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "reviewId")
+	})
+
+	t.Run("Not found", func(t *testing.T) {
+		// Create a payload for updating a review
+		updatedReview := models.GameReview{
+			Review: "Updated review",
+			Rating: "1",
+		}
+		updatedReviewJSON, err := json.Marshal(updatedReview)
+		if err != nil {
+			t.Fatalf("Error marshalling updated review: %v", err)
+		}
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/games/reviews/{reviewId}", bytes.NewReader(updatedReviewJSON))
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "999999"})
+
+		gamesHandler.UpdateGameReviewHandler(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "error")
+	})
+
+}
+
+func TestDeleteGameReviewHandler(t *testing.T) {
+	gamesHandler := setupTestEnvironment(t)
+
+	t.Run("Not found", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("DELETE", "/games/reviews/{reviewId}", nil)
+		req = mux.SetURLVars(req, map[string]string{"reviewId": "999999"})
+
+		gamesHandler.DeleteGameReviewHandler(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rr.Body)
+		assert.Contains(t, rr.Body.String(), "error")
+	})
+}


### PR DESCRIPTION
Added more integration tests for the handlers that don't access IGDB. These tests use the testify package instead of golang's own testing suite.